### PR TITLE
Remove cursor: pointer from code

### DIFF
--- a/_elements.forms.scss
+++ b/_elements.forms.scss
@@ -38,7 +38,6 @@ legend,
 label {
     display: block;
     width: 100%;
-    cursor: pointer;
 }
 
 legend {


### PR DESCRIPTION
Removes `cursor: pointer` setting as described in https://github.com/getchopstick/chopstick-boilerplate/issues/122
